### PR TITLE
Add options to change spell check for messages

### DIFF
--- a/Toxy/Common/Config/Config.cs
+++ b/Toxy/Common/Config/Config.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Security.Policy;
 using System.Windows;
 using SharpTox.Core;
 
@@ -38,6 +39,22 @@ namespace Toxy.Common
             get { return alwaysNotify; }
             set { alwaysNotify = value; }
         }
+
+	    private bool enableSpellcheck = true;
+
+	    public bool EnableSpellcheck
+	    {
+			get { return this.enableSpellcheck; }
+			set { this.enableSpellcheck = value; }
+	    }
+
+	    private SpellcheckLanguage spellcheckLanguage;
+
+	    public SpellcheckLanguage SpellcheckLanguage
+	    {
+			get { return this.spellcheckLanguage; }
+			set { this.spellcheckLanguage = value; }
+	    }
 
        private bool ipv6Enabled = true;
 

--- a/Toxy/Common/SpellcheckLanguage.cs
+++ b/Toxy/Common/SpellcheckLanguage.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel;
+
+namespace Toxy.Common
+{
+	public enum SpellcheckLanguage
+	{
+		/*
+		 * The languages below are the only 4 supported by the WPF spellcheck feature.
+		 * See here: http://stackoverflow.com/a/209266/3071361
+		 */
+
+		[Description("en-US")]
+		English,
+		[Description("fr")]
+		French,
+		[Description("de")]
+		German,
+		[Description("es")]
+		Spanish
+	}
+}

--- a/Toxy/Converter/IetfTagToXmlLanguageConverter.cs
+++ b/Toxy/Converter/IetfTagToXmlLanguageConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Markup;
+
+namespace Toxy.Converter
+{
+	public class IetfTagToXmlLanguageConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			var ietfTag = value as string;
+
+			return ietfTag == null ? Binding.DoNothing : XmlLanguage.GetLanguage(ietfTag);
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			var xmlLang = value as XmlLanguage;
+
+			return xmlLang == null ? Binding.DoNothing : xmlLang.IetfLanguageTag;
+		}
+	}
+}

--- a/Toxy/Extensions/EnumExtensions.cs
+++ b/Toxy/Extensions/EnumExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Toxy.Extensions
+{
+	public static class EnumExtensions
+	{
+		/// <summary>
+		/// Takes the specified enum and returns the content of its description attribute, or the name of the enum
+		/// if no description has been set
+		/// </summary>
+		/// <param name="value">The enum of that the description should be returned</param>
+		/// <returns>A string, containing the description of the specified enum, or its name converted to string</returns>
+		public static string ToDescription(this Enum value)
+		{
+			var descAttribute = (DescriptionAttribute[]) (value.GetType().GetField(value.ToString()))
+				.GetCustomAttributes(typeof (DescriptionAttribute), false);
+			
+			return (descAttribute.Length > 0) ? descAttribute[0].Description : value.ToString();
+		}
+	}
+}

--- a/Toxy/MainWindow.xaml
+++ b/Toxy/MainWindow.xaml
@@ -3,6 +3,7 @@
                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                      xmlns:globalization="clr-namespace:System.Globalization;assembly=mscorlib"
                       mc:Ignorable="d"
                       d:DesignHeight="400"
                       d:DesignWidth="600"
@@ -628,7 +629,9 @@
                          TextChanged="TextToSend_TextChanged"
                          AcceptsReturn="True"
                          SelectionBrush="{DynamicResource AccentColorBrush}"
-                         SpellCheck.IsEnabled="True"/>
+                         SpellCheck.IsEnabled="{Binding SpellcheckEnabled}"
+                         Language="{Binding SpellcheckLangCode, Converter={StaticResource IetfTagToXmlLanguageConverter}, ConverterCulture={x:Static globalization:CultureInfo.CurrentCulture}}"
+                     />
             <GridSplitter Grid.Column="1" Grid.Row="1" Grid.RowSpan="3"
                       Width="1"
                       HorizontalAlignment="Center"
@@ -821,6 +824,27 @@
                                       Margin="0,5,0,0"
                                       IsEnabled="{Binding ElementName=AudioNotificationCheckBox, Path=IsChecked}"
                                       Content="Always play sound, even when Toxy is open"
+                                      />
+                            <Label VerticalAlignment="Top"
+                                   HorizontalAlignment="Left"
+                                   Margin="0,10,0,0"
+                                   Content="Spellcheck settings"
+                                   />
+                            <CheckBox x:Name="SpellcheckCheckBox"
+                                      VerticalAlignment="Top"
+                                      HorizontalAlignment="Left"
+                                      Margin="0,5,0,0"
+                                      Content="Check my spelling"
+                                      ToolTip="Underlines misspelled words in the message box."
+                                      />
+                            <ComboBox x:Name="SpellcheckLanguageComboBox"
+                                      VerticalAlignment="Top"
+                                      HorizontalAlignment="Left"
+                                      Margin="0,5,0,0"
+                                      IsEnabled="{Binding ElementName=SpellcheckCheckBox, Path=IsChecked}"
+                                      ItemsSource="{Binding SpellcheckLanguages}"
+                                      ToolTip="The language in which spelling should be checked."
+                                      Width="275"
                                       />
                             <StackPanel Margin="0 10 0 0" Orientation="Horizontal">
                                 <Label Content="Proxy address"

--- a/Toxy/MainWindow.xaml.cs
+++ b/Toxy/MainWindow.xaml.cs
@@ -38,6 +38,7 @@ using Brushes = System.Windows.Media.Brushes;
 using SQLite;
 using NAudio.Wave;
 using SharpTox.Vpx;
+using Toxy.Extensions;
 
 namespace Toxy
 {
@@ -1232,6 +1233,9 @@ namespace Toxy
             Width = config.WindowSize.Width;
             Height = config.WindowSize.Height;
 
+	        ViewModel.SpellcheckEnabled = config.EnableSpellcheck;
+	        ViewModel.SpellcheckLangCode = config.SpellcheckLanguage.ToDescription();
+
             ExecuteActionsOnNotifyIcon();
         }
 
@@ -1879,6 +1883,8 @@ namespace Toxy
                 PortableCheckBox.IsChecked = config.Portable;
                 AudioNotificationCheckBox.IsChecked = config.EnableAudioNotifications;
                 AlwaysNotifyCheckBox.IsChecked = config.AlwaysNotify;
+	            SpellcheckCheckBox.IsChecked = config.EnableSpellcheck;
+				SpellcheckLanguageComboBox.SelectedItem = Enum.GetName(typeof(SpellcheckLanguage), config.SpellcheckLanguage);
                 FilterAudioCheckbox.IsChecked = config.FilterAudio;
 
                 if (!string.IsNullOrEmpty(config.ProxyAddress))
@@ -2043,6 +2049,11 @@ namespace Toxy
             config.Portable = (bool)PortableCheckBox.IsChecked;
             config.EnableAudioNotifications = (bool)AudioNotificationCheckBox.IsChecked;
             config.AlwaysNotify = (bool)AlwaysNotifyCheckBox.IsChecked;
+	        config.EnableSpellcheck = (bool)SpellcheckCheckBox.IsChecked;
+	        config.SpellcheckLanguage = (SpellcheckLanguage)Enum.Parse(typeof (SpellcheckLanguage), SpellcheckLanguageComboBox.SelectedItem.ToString());
+
+	        ViewModel.SpellcheckLangCode = config.SpellcheckLanguage.ToDescription();
+	        ViewModel.SpellcheckEnabled = config.EnableSpellcheck;
             ExecuteActionsOnNotifyIcon();
 
             bool filterAudio = (bool)FilterAudioCheckbox.IsChecked;

--- a/Toxy/Styles/CustomStyles.xaml
+++ b/Toxy/Styles/CustomStyles.xaml
@@ -17,6 +17,7 @@
     <converter:BoolToVisibilityConverter x:Key="FalseToVisibilityConverter"
                                          TrueValue="Collapsed"
                                          FalseValue="Visible" />
+    <converter:IetfTagToXmlLanguageConverter x:Key="IetfTagToXmlLanguageConverter"/>
     <converter:ToxUserStatusToBrushConverter x:Key="ToxUserStatusToBrushConverter" />
 
     <DataTemplate x:Key="WindowTitleDataTemplate">

--- a/Toxy/Toxy.csproj
+++ b/Toxy/Toxy.csproj
@@ -133,7 +133,10 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="Common\AvatarStore.cs" />
+    <Compile Include="Common\SpellcheckLanguage.cs" />
     <Compile Include="Common\ToxStatus.cs" />
+    <Compile Include="Converter\IetfTagToXmlLanguageConverter.cs" />
+    <Compile Include="Extensions\EnumExtensions.cs" />
     <Compile Include="Properties\BuildInfo.cs" />
     <Compile Include="Common\Transfers\FileReceiver.cs" />
     <Compile Include="Common\Transfers\FileSender.cs" />

--- a/Toxy/ViewModels/MainWindowViewModel.cs
+++ b/Toxy/ViewModels/MainWindowViewModel.cs
@@ -1,13 +1,16 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows;
+using System.Windows.Markup;
 using System.Windows.Media;
 
 using MahApps.Metro;
 using Toxy.MVVM;
 using NAudio.Wave;
 using AForge.Video.DirectShow;
+using Toxy.Common;
 
 namespace Toxy.ViewModels
 {
@@ -62,6 +65,8 @@ namespace Toxy.ViewModels
                                           .Select(a => new AppThemeMenuData() { Name = a.Name, BorderColorBrush = a.Resources["BlackColorBrush"] as Brush, ColorBrush = a.Resources["WhiteColorBrush"] as Brush })
                                           .ToList();
 
+	        this.SpellcheckLanguages = Enum.GetNames(typeof(SpellcheckLanguage)).ToList();
+
             InputDevices = new ObservableCollection<InputDeviceMenuData>();
             OutputDevices = new ObservableCollection<OutputDeviceMenuData>();
             VideoDevices = new ObservableCollection<VideoDeviceMenuData>();
@@ -69,6 +74,7 @@ namespace Toxy.ViewModels
 
         public List<AccentColorMenuData> AccentColors { get; set; }
         public List<AppThemeMenuData> AppThemes { get; set; }
+		public List<string> SpellcheckLanguages { get; set; }
 
         public ObservableCollection<OutputDeviceMenuData> OutputDevices { get; set; }
         public ObservableCollection<InputDeviceMenuData> InputDevices { get; set; }
@@ -238,5 +244,37 @@ namespace Toxy.ViewModels
             };
             this.ChatCollection = chatObjects;
         }
+
+	    private bool spellcheckEnabled;
+
+	    public bool SpellcheckEnabled
+	    {
+			get { return this.spellcheckEnabled; }
+		    set
+		    {
+			    if (Equals(value, this.spellcheckEnabled))
+			    {
+				    return;
+			    }
+			    this.spellcheckEnabled = value;
+				this.OnPropertyChanged(() => this.SpellcheckEnabled);
+		    }
+	    }
+
+	    private string spellcheckLangCode;
+
+	    public string SpellcheckLangCode
+	    {
+			get { return this.spellcheckLangCode; }
+		    set
+		    {
+			    if (Equals(value, this.spellcheckLangCode))
+			    {
+				    return;
+			    }
+			    this.spellcheckLangCode = value;
+				this.OnPropertyChanged(() => this.SpellcheckLangCode);
+		    }
+	    }
     }
 }


### PR DESCRIPTION
Adds the functionality requested in issue #49 

Spell checking defaults to being enabled and using the english dictionary.